### PR TITLE
Update MagicHome Wifi — Bulb (RGB + WW-CW CCT).groovy

### DIFF
--- a/Drivers/MagicHome/MagicHome Wifi — Bulb (RGB + WW-CW CCT).groovy
+++ b/Drivers/MagicHome/MagicHome Wifi — Bulb (RGB + WW-CW CCT).groovy
@@ -241,7 +241,7 @@ def setColorTemperature( setTemp = device.currentValue("colorTemperature"), devi
 	}
 
 	sendEvent(name: "warmWhiteLevel", value: brightnessWW)
-	sendEvent(name: "coldWhiteLevel", valur: brightnessCW)
+	sendEvent(name: "coldWhiteLevel", value: brightnessCW)
 	sendEvent(name: "colorMode", value: "CT")
    
 


### PR DESCRIPTION
Typo caused java.lang.NullPointerException: Cannot execute null+30.0000000000 on line 467 (parse) error.  coldWhiteLevel remains null rather than zero which generates the error.  The device will not initialize until coldWhitelevel has a non-null value.