### PR TITLE
crash fix

### DIFF
--- a/Apps/CircadianDaylight.groovy
+++ b/Apps/CircadianDaylight.groovy
@@ -564,7 +564,7 @@ def getCTBright() {
 	}
 
 	
-    if( ( currentTime > sunriseTime.time && currentTime < sunsetTime.time ) || ( brightenStart != null && dimEnd != null && ( currentTime > brightenStart && currentTime < dimEnd ) ) ) { // time is between sunrise and sunset
+    if( ( currentTime > sunriseTime.time && currentTime < sunsetTime.time ) || ( brightenStart != null && dimEnd != null && ( currentTime > brightenStart.time && currentTime < dimEnd.time ) ) ) { // time is between sunrise and sunset
 
         if(currentTime < midDay) {
             colorTemp = warmCT + ((currentTime - sunriseTime.time) / (midDay - sunriseTime.time) * midCT)


### PR DESCRIPTION
Line 568 was causing modeHandler to crash, as brightenStart and dimEnd are dates while the values they were being compared to were times.  Fixed by changing the references to brightenStart.time and dimEnd.time.