### PR TITLE
Circadian Daylight: Fix typo in menu section for advanced color temperature options

### DIFF
--- a/Apps/CircadianDaylight.groovy
+++ b/Apps/CircadianDaylight.groovy
@@ -118,7 +118,7 @@ def mainPage(){
             href(name: "toColorTemperatureOverrides",
                     title: "<b>Color Temperature Options</b>",
                     page: "colorTemperatureOverrides",
-                    description: "Set Advanced Sunset/Sunrise Options"
+                    description: "Set Advanced Color Temperature Options"
             )
         }
 


### PR DESCRIPTION
Happened to notice this while setting up the app. I think this was a copy/paste error.